### PR TITLE
Revert date picker to old design and additional bug fixes

### DIFF
--- a/PulseEco.xcodeproj/project.pbxproj
+++ b/PulseEco.xcodeproj/project.pbxproj
@@ -44,6 +44,11 @@
 		3288687624B51F5E009CC56D /* MarkerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3288687224B51F5E009CC56D /* MarkerView.xib */; };
 		3288687724B51F5E009CC56D /* MarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3288687324B51F5E009CC56D /* MarkerView.swift */; };
 		3288687924B5C053009CC56D /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3288687824B5C053009CC56D /* UIViewExtension.swift */; };
+		565A2D402DC4C202001AB36F /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565A2D3C2DC4C1FD001AB36F /* ArrayExtensions.swift */; };
+		565A2D412DC4C202001AB36F /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565A2D3C2DC4C1FD001AB36F /* ArrayExtensions.swift */; };
+		565A2D422DC4C202001AB36F /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565A2D3C2DC4C1FD001AB36F /* ArrayExtensions.swift */; };
+		56DFA98F2DC24D73007E8528 /* DateSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DFA98E2DC24D6E007E8528 /* DateSlider.swift */; };
+		56DFA9912DC24DF5007E8528 /* WeekDayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DFA9902DC24DF2007E8528 /* WeekDayButton.swift */; };
 		5908ADE224AF2DA500C79BC9 /* DateFormatterUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5908ADE124AF2DA500C79BC9 /* DateFormatterUtils.swift */; };
 		59103AA024A4B64C00ED9617 /* DisclaimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59103A9F24A4B64C00ED9617 /* DisclaimerView.swift */; };
 		591642A52499FD70000A4F7C /* CityMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591642A42499FD70000A4F7C /* CityMapView.swift */; };
@@ -262,6 +267,9 @@
 		3288687224B51F5E009CC56D /* MarkerView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MarkerView.xib; sourceTree = "<group>"; };
 		3288687324B51F5E009CC56D /* MarkerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkerView.swift; sourceTree = "<group>"; };
 		3288687824B5C053009CC56D /* UIViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
+		565A2D3C2DC4C1FD001AB36F /* ArrayExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtensions.swift; sourceTree = "<group>"; };
+		56DFA98E2DC24D6E007E8528 /* DateSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSlider.swift; sourceTree = "<group>"; };
+		56DFA9902DC24DF2007E8528 /* WeekDayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekDayButton.swift; sourceTree = "<group>"; };
 		5908ADE124AF2DA500C79BC9 /* DateFormatterUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatterUtils.swift; sourceTree = "<group>"; };
 		59103A9F24A4B64C00ED9617 /* DisclaimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclaimerView.swift; sourceTree = "<group>"; };
 		591642A42499FD70000A4F7C /* CityMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityMapView.swift; sourceTree = "<group>"; };
@@ -417,9 +425,11 @@
 		1E3A38AD280EBC4B002C4A54 /* History and Forecast */ = {
 			isa = PBXGroup;
 			children = (
+				56DFA9902DC24DF2007E8528 /* WeekDayButton.swift */,
 				13A95BA52D37E95F004F502A /* DateSelectorViewModel.swift */,
 				1E96776E280FFEB60085C37A /* CalendarDayButton.swift */,
 				1EAF05F72817E89B001C1EEA /* CalendarView.swift */,
+				56DFA98E2DC24D6E007E8528 /* DateSlider.swift */,
 				1EAF05F92817F653001C1EEA /* DateValueModel.swift */,
 				1E3B8363282E4CED00EED04D /* CalendarButtonView.swift */,
 				74A0D84C2833A9010043222E /* CalendarViewModel.swift */,
@@ -450,6 +460,14 @@
 				3288687824B5C053009CC56D /* UIViewExtension.swift */,
 			);
 			path = Markers;
+			sourceTree = "<group>";
+		};
+		565A2D432DC4C21A001AB36F /* Extenions */ = {
+			isa = PBXGroup;
+			children = (
+				565A2D3C2DC4C1FD001AB36F /* ArrayExtensions.swift */,
+			);
+			path = Extenions;
 			sourceTree = "<group>";
 		};
 		59103A9E24A4B62F00ED9617 /* Disclamer */ = {
@@ -757,6 +775,7 @@
 		D03524D22736055A0089E11C /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				565A2D432DC4C21A001AB36F /* Extenions */,
 				C52F371C26F240FC007813B0 /* KeyboardDismissModifier.swift */,
 				730B4DE3299E5E3800B32089 /* UserDefaultsEnumWrapper.swift */,
 			);
@@ -1039,8 +1058,10 @@
 				73CD1F29297AB580004E3347 /* SettingsView.swift in Sources */,
 				133B20C22CFF19120034AEF6 /* LoggerProtocol.swift in Sources */,
 				59F01AD724AC7B1300AD2802 /* AppDataSource.swift in Sources */,
+				56DFA98F2DC24D73007E8528 /* DateSlider.swift in Sources */,
 				5908ADE224AF2DA500C79BC9 /* DateFormatterUtils.swift in Sources */,
 				59103AA024A4B64C00ED9617 /* DisclaimerView.swift in Sources */,
+				565A2D402DC4C202001AB36F /* ArrayExtensions.swift in Sources */,
 				59504C1724B46CA700EA4AFF /* LineGraph.swift in Sources */,
 				74A0D84D2833A9010043222E /* CalendarViewModel.swift in Sources */,
 				593C263824BC89BE005152BE /* CityRowViewModel.swift in Sources */,
@@ -1101,6 +1122,7 @@
 				32479108261A6F7200E97C56 /* SlideOverCard.swift in Sources */,
 				59B0019024C9C269006EA796 /* ChartsDateValueFormatter.swift in Sources */,
 				59FAD1D42490C82600AC36A5 /* City.swift in Sources */,
+				56DFA9912DC24DF5007E8528 /* WeekDayButton.swift in Sources */,
 				59A35AD22498F1C800C07786 /* AppColors.swift in Sources */,
 				593C264524BCAD19005152BE /* SearchBar.swift in Sources */,
 				593C264324BC9E01005152BE /* UserSettings.swift in Sources */,
@@ -1130,6 +1152,7 @@
 				D03524CD273604D60089E11C /* UserSettings.swift in Sources */,
 				D03524D0273605410089E11C /* DateFormatterUtils.swift in Sources */,
 				D03524C8273603800089E11C /* SensorTypes.swift in Sources */,
+				565A2D412DC4C202001AB36F /* ArrayExtensions.swift in Sources */,
 				D03524C6273603800089E11C /* City.swift in Sources */,
 				D03524CB273603800089E11C /* SensorPin.swift in Sources */,
 				D03EC9052735E7EC00E6E16F /* WidgetTimelineProvider.swift in Sources */,
@@ -1154,6 +1177,7 @@
 				744A9DF128575CA700A91789 /* Calendar.swift in Sources */,
 				D0CBADFF27761A9E00526050 /* DateFormatterUtils.swift in Sources */,
 				D0CBADF62776108E00526050 /* SensorPin.swift in Sources */,
+				565A2D422DC4C202001AB36F /* ArrayExtensions.swift in Sources */,
 				1E515D0C282BC115009EFC4D /* DayDataWrapper.swift in Sources */,
 				D0CBADF52776108E00526050 /* City.swift in Sources */,
 				730B4DE629A368C900B32089 /* UserDefaultsEnumWrapper.swift in Sources */,

--- a/PulseEco/AppRoot/MainView.swift
+++ b/PulseEco/AppRoot/MainView.swift
@@ -90,8 +90,6 @@ struct MainView: View {
                         
                         ZStack(alignment: .top) {
                             DateSelector()
-                                .padding(.horizontal)
-                                .padding(.vertical, 8)
                                 .zIndex(2)
                             
                             CityMapView(userSettings: self.appState.userSettings,

--- a/PulseEco/History and Forecast/CalendarView.swift
+++ b/PulseEco/History and Forecast/CalendarView.swift
@@ -1,5 +1,5 @@
 //
-//  CustomCalendar.swift
+//  CalendarView.swift
 //  PulseEco
 //
 //  Created by Sara Karachanakova on 26.4.22.
@@ -12,35 +12,32 @@ private enum PickerType {
 }
 
 struct CalendarView: View {
-    
     @EnvironmentObject var dataSource: AppDataSource
-    
+
     @StateObject private var viewModel: CalendarViewModel
     @State private var pickerType: PickerType = .day
-    
+
     @Binding var showingCalendar: Bool
     @Binding var selectedDate: Date
     @Binding var calendarSelection: Date
-    
+
     var onDaySelected: ((Date) -> Void)?
-    
+
     init(showingCalendar: Binding<Bool>,
          selectedDate: Binding<Date>,
          calendarSelection: Binding<Date>,
          onDaySelected: ((Date) -> Void)?,
-         viewModelClosure: @autoclosure @escaping () -> CalendarViewModel) {
-        
+         viewModelClosure: @autoclosure @escaping () -> CalendarViewModel)
+    {
         _viewModel = StateObject(wrappedValue: viewModelClosure())
         _showingCalendar = showingCalendar
         _selectedDate = selectedDate
         _calendarSelection = calendarSelection
         self.onDaySelected = onDaySelected
     }
-    
+
     var body: some View {
-        VStack {
-            pickerOptionButtonsView
-            
+        VStack(spacing: 10) {
             switch pickerType {
             case .day:
                 dayPicker
@@ -56,44 +53,36 @@ struct CalendarView: View {
         }
         .padding(.all)
         .background(Color.white)
-        .onAppear {
-            viewModel.dateValues = viewModel.extractDate()
-        }
+        .task(viewModel.setupDates)
     }
-    
-    private var pickerOptionButtonsView: some View {
-        HStack {
-            Button(action: {
-                pickerType = .day
-            }) {
-                Text("Day") //add trema (day_for_weekly_average_data)?
-                    .padding(8)
-                    .background(pickerType == .day ? Color(AppColors.firstButtonColor) : Color.white)
-                    .cornerRadius(8)
-                    .foregroundStyle(pickerType == .day ? Color.white : Color(AppColors.firstButtonColor))
-                    .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color(AppColors.firstButtonColor), lineWidth: 2)
-                    )
+
+    @ViewBuilder
+    private func calendarDaysView(value: DateValueModel, color: String) -> some View {
+        VStack {
+            if value.day != -1 {
+                Button {
+                    self.selectedDate = calendar.startOfDay(for: value.date)
+                    self.calendarSelection = calendar.startOfDay(for: value.date)
+                    Task {
+                        do {
+                            await viewModel.appDataSource.updatePins(selectedDate: selectedDate)
+                            await viewModel.appDataSource.selectFromCalendar()
+                        }
+                    }
+                    showingCalendar = false
+                } label: {
+                    CalendarButtonView(day: value.day,
+                                       date: value.date,
+                                       color: color,
+                                       highlighted: value.date.isSameDay(with: selectedDate))
+                }
+                .disabled(value.date > calendar.startOfDay(for: Date.now) ? true : false)
             }
-            
-            Button(action: {
-                pickerType = .month
-            }) {
-                Text("Month") // add trema
-                    .padding(8)
-                    .background(pickerType == .month ? Color(AppColors.firstButtonColor) : Color.white)
-                    .cornerRadius(8)
-                    .foregroundStyle(pickerType == .month ? Color.white : Color(AppColors.firstButtonColor))
-                    .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color(AppColors.firstButtonColor), lineWidth: 2)
-                    )
-            }
-            Spacer()
         }
+        .padding(.vertical, 5)
+        .frame(height: 20, alignment: .top)
     }
-    
+
     @ViewBuilder
     var dayPicker: some View {
         VStack {
@@ -101,26 +90,17 @@ struct CalendarView: View {
             VStack {
                 HStack(spacing: 0) {
                     ForEach(viewModel.daysOfWeekShort, id: \.self) { day in
-                        Text( String(day.prefix(1)).capitalized )
+                        Text(String(day.prefix(1)).capitalized)
                             .frame(maxWidth: .infinity)
                             .font(.system(size: 12, weight: .regular))
                             .foregroundColor(Color(AppColors.greyColor))
                     }
                 }
                 HStack(spacing: 0) {
-                    
                     let columns = Array(repeating: GridItem(.flexible()), count: 7)
-                    
-                    LazyVGrid(columns: columns, spacing: 5) {
-                        ForEach(viewModel.monthlyData, id: \.self) { data in
-                            CalendarDayButton(date: data.date,
-                                          value: data.value,
-                                          color: data.color,
-                                          highlighted: selectedDate.isSameDay(with: data.date)) {
-                                self.selectedDate = calendar.startOfDay(for: data.date)
-                                self.calendarSelection = calendar.startOfDay(for: data.date)
-                                onDaySelected?(selectedDate)
-                            }
+                    LazyVGrid(columns: columns, spacing: 20) {
+                        ForEach(viewModel.dateValues, id: \.id) { value in
+                            calendarDaysView(value: value, color: value.color)
                         }
                     }
                 }
@@ -128,7 +108,7 @@ struct CalendarView: View {
             okAndCancelStack
         }
     }
-    
+
     private var okAndCancelStack: some View {
         HStack {
             Spacer()
@@ -141,8 +121,9 @@ struct CalendarView: View {
             }
             .padding(.top)
         }
+        .padding(.all)
     }
-    
+
     @ViewBuilder
     private var monthSelectionStack: some View {
         HStack {
@@ -175,7 +156,7 @@ struct CalendarView: View {
                     .padding(.leading)
             }
             .padding(.all)
-            
+
             Button {
                 Task {
                     await viewModel.nextMonth()
@@ -191,13 +172,12 @@ struct CalendarView: View {
             .padding(.all)
         }
     }
-    
+
     @ViewBuilder
     private var yearPicker: some View {
-        
         let currentYear = calendar.component(.year, from: Date())
-        let years = 2017...currentYear
-        
+        let years = 2017 ... currentYear
+
         VStack {
             HStack {
                 Button {
@@ -210,7 +190,7 @@ struct CalendarView: View {
                 Spacer()
             }
             .padding(.top, 0)
-            
+
             let columns = Array(repeating: GridItem(.flexible()), count: 4)
             LazyVGrid(columns: columns, spacing: 20) {
                 ForEach(years, id: \.self) { year in
@@ -233,7 +213,7 @@ struct CalendarView: View {
                 }
             }
             .padding(.top)
-            
+
             HStack {
                 Spacer()
                 Button {
@@ -249,7 +229,7 @@ struct CalendarView: View {
         }
         .padding(.top)
     }
-    
+
     @ViewBuilder
     private var monthPicker: some View {
         VStack {
@@ -267,9 +247,9 @@ struct CalendarView: View {
                 Spacer()
             }
             .padding(.top, 0)
-            
+
             let columns = Array(repeating: GridItem(.flexible()), count: 4)
-            
+
             LazyVGrid(columns: columns, spacing: 10) {
                 ForEach(viewModel.monthValues, id: \.self) { val in
                     Button {
@@ -288,7 +268,7 @@ struct CalendarView: View {
                 }
             }
             .padding(.top)
-            
+
             okAndCancelStack
         }
         .padding(.top)

--- a/PulseEco/History and Forecast/CalendarViewModel.swift
+++ b/PulseEco/History and Forecast/CalendarViewModel.swift
@@ -10,55 +10,68 @@ import Foundation
 
 @MainActor
 class CalendarViewModel: ViewModelProtocol {
-    
     @Published var monthlyData: [DayDataWrapper] = []
     @Published var currentDate: Date
-    @Published var currentMonthOffset = 0
+    @Published var currentMonthOffset: Int
     @Published var selectedYear: Int
     @Published var selectedMonth: Int
     @Published var dateValues: [DateValueModel] = []
     @Published var monthValues: [DayDataWrapper] = []
-    
+
     private let appState: AppState
     let appDataSource: AppDataSource
     private var cancelables = Set<AnyCancellable>()
-    
+
     init(appState: AppState, appDataSource: AppDataSource) {
         self.appState = appState
         self.appDataSource = appDataSource
         currentDate = appState.selectedDate
         selectedYear = calendar.component(.year, from: appState.selectedDate)
         selectedMonth = calendar.component(.month, from: appState.selectedDate)
-        
-        self.appDataSource.$monthlyData.sink {
+        currentMonthOffset = calendar.component(.month, from: appState.selectedDate) - calendar.component(.month, from: Date())
+
+        self.appDataSource.$monthlyData.sink { [weak self] in
+            guard let self else { return }
             self.monthlyData = self.getMonthlyValuesForPresentation(monthlyData: $0)
+            self.colorDays()
         }
         .store(in: &cancelables)
     }
-    
+
     func getCurrentMonth() -> Date {
-        
-        let yearOffset = self.selectedYear - calendar.component(.year, from: Date())
-        
+        let yearOffset = selectedYear - calendar.component(.year, from: Date())
+
         guard let newDate = calendar.date(byAdding: .year,
                                           value: yearOffset,
-                                          to: Date()) else {
+                                          to: Date())
+        else {
             return Date()
         }
-        
+
         guard let currentMonth = calendar.date(byAdding: .month,
                                                value: currentMonthOffset,
-                                               to: newDate) else {
+                                               to: newDate)
+        else {
             return Date()
         }
-        
+
         return currentMonth
     }
     
+    @Sendable
+    func setupDates() async {
+        let monthlyDataMonth = monthlyData.map { calendar.component(.month, from: $0.date) }.mostFrequentValue
+        let currentMonth = calendar.component(.month, from: currentDate)
+        dateValues = extractDate()
+        if currentMonth != monthlyDataMonth {
+            let currentYear = calendar.component(.year, from: currentDate)
+            await appDataSource.fetchMonthlyDayData(selectedMonth: currentMonth, selectedYear: currentYear)
+        }
+    }
+
     func extractDate() -> [DateValueModel] {
-        
         let currentMonth = getCurrentMonth()
-        
+
         var days = currentMonth.getDaysOfMonth().compactMap { date -> DateValueModel in
             var color = "gray"
             let day = calendar.component(.day, from: date)
@@ -73,30 +86,41 @@ class CalendarViewModel: ViewModelProtocol {
             let first = calendar.component(.weekday, from: days.first?.date ?? Date()) - 1
             return first > 0 ? first : 7
         }()
-        for _ in 1..<firstWeekDay {
+        for _ in 1 ..< firstWeekDay {
             days.insert(DateValueModel(day: -1, date: Date(), color: "gray"), at: 0)
         }
         return days
     }
-    
+
+    func colorDays() {
+        dateValues = dateValues.map { dateValue in
+            var color = "gray"
+            for element in monthlyData where isSameDay(date1: element.date, date2: dateValue.date) {
+                color = element.color
+            }
+            return DateValueModel(day: dateValue.day, date: dateValue.date, color: color)
+        }
+    }
+
     func getMonthlyValuesForPresentation(monthlyData: [DayDataWrapper]) -> [DayDataWrapper] {
         let daysOfMonthCount = getCurrentMonth().getDaysOfMonth().count
-        
+
         let firstWeekDay: Int = {
             let first = calendar.component(.weekday, from: monthlyData.first?.date ?? Date()) - 1
             return first > 0 ? first : 7
         }()
-        
+
         var presentableValues: [DayDataWrapper] = []
         var monthlyDataCopy = monthlyData
         let dayNow = calendar.component(.day, from: .now)
-        for i in 1..<daysOfMonthCount+1 {
+        for i in 1 ..< daysOfMonthCount + 1 {
             guard let data = monthlyDataCopy.first,
-                  let date = monthlyDataCopy.first?.date else {
+                  let date = monthlyDataCopy.first?.date
+            else {
                 if i == dayNow {
                     let today = appDataSource.fetchTodayValue(cityName: appState.selectedCity.cityName,
                                                               sensorType: appState.selectedMeasureId)
-                    
+
                     if let todayData = today {
                         presentableValues.append(DayDataWrapper(date: todayData.date, value: todayData.value, color: todayData.color))
                         continue
@@ -105,7 +129,7 @@ class CalendarViewModel: ViewModelProtocol {
                         continue
                     }
                 }
-                
+
                 presentableValues.append(DayDataWrapper(date: calendar.date(bySetting: .day, value: i, of: currentDate)!, value: "", color: "gray"))
                 continue
             }
@@ -117,49 +141,46 @@ class CalendarViewModel: ViewModelProtocol {
                 presentableValues.append(DayDataWrapper(date: calendar.date(bySetting: .day, value: i, of: currentDate)!, value: "", color: "gray"))
             }
         }
-        
-        for _ in 1..<firstWeekDay {
+
+        for _ in 1 ..< firstWeekDay {
             presentableValues.insert(DayDataWrapper(date: .distantPast, value: "-1", color: "gray"), at: 0)
         }
-        
+
         return presentableValues
     }
-    
+
     func isSameDay(date1: Date, date2: Date) -> Bool {
         let diff = calendar.dateComponents([.day], from: date1, to: date2)
         return diff.day == 0
     }
-    
-    var daysOfWeekShort: [String] = {
-        
-        return [
-            Trema.text(for: "monday-short"),
-            Trema.text(for: "tuesday-short"),
-            Trema.text(for: "wednesday-short"),
-            Trema.text(for: "thursday-short"),
-            Trema.text(for: "friday-short"),
-            Trema.text(for: "saturday-short"),
-            Trema.text(for: "sunday-short")]
-    }()
-    
+
+    var daysOfWeekShort: [String] = [
+        Trema.text(for: "monday-short"),
+        Trema.text(for: "tuesday-short"),
+        Trema.text(for: "wednesday-short"),
+        Trema.text(for: "thursday-short"),
+        Trema.text(for: "friday-short"),
+        Trema.text(for: "saturday-short"),
+        Trema.text(for: "sunday-short"),
+    ]
+
     func extraDate() -> String {
-        
         let formatter = DateFormatter()
         formatter.dateFormat = "MMMM yyy"
         formatter.locale = Locale(identifier: Trema.appLanguageLocale)
-        
+
         let date = formatter.string(from: currentDate)
-        
+
         return shortDate(from: date)
     }
-    
+
     func shortDate(from date: String) -> String {
         let prefix = date.prefix(3)
         let suffix = date.suffix(4)
-        
+
         return prefix + " " + suffix
     }
-    
+
     func previousMonth() {
         let yearChange = selectedMonth == 1
         if yearChange {
@@ -180,6 +201,7 @@ class CalendarViewModel: ViewModelProtocol {
             await appDataSource.fetchMonthlyDayData(selectedMonth: selectedMonth, selectedYear: selectedYear)
         }
     }
+
     func nextMonth() async {
         let yearChange = selectedMonth >= 11
         if yearChange {
@@ -200,17 +222,18 @@ class CalendarViewModel: ViewModelProtocol {
             await appDataSource.fetchMonthlyDayData(selectedMonth: selectedMonth, selectedYear: selectedYear)
         }
     }
+
     func selectNewMonth(month: String) async {
         selectedMonth = calendar.shortMonthSymbols.firstIndex(of: month) ?? selectedMonth
         currentMonthOffset = selectedMonth - calendar.component(.month, from: Date())
         await nextMonth()
     }
-    
+
     func colorMonths() {
         let currentYear = selectedYear
         let from = Date.from(1, 1, currentYear)!
         let to = Date.from(31, 12, currentYear)!
-        
+
         monthValues = appDataSource.monthlyAverage.getDataFromRange(cityName: appState.selectedCity.cityName,
                                                                     sensorType: appState.selectedMeasureId,
                                                                     from: from, to: to)
@@ -223,16 +246,17 @@ class CalendarViewModel: ViewModelProtocol {
         for month in missingMonths {
             monthValues.append(DayDataWrapper(date: Date.from(1, month, currentYear)!, value: "", color: "darkblue"))
         }
-        monthValues = monthValues.sorted(by: { $0.month < $1.month})
+        monthValues = monthValues.sorted(by: { $0.month < $1.month })
         Task {
             await appDataSource.fetchMonthlyDayData(selectedMonth: selectedMonth, selectedYear: selectedYear)
         }
     }
-    
+
     func isCurrentMonthSelected() -> Bool {
         return calendar.component(.month, from: currentDate) == calendar.component(.month, from: .now)
     }
 }
+
 extension Array where Element: Hashable {
     func difference(from other: [Element]) -> [Element] {
         let thisSet = Set(self)

--- a/PulseEco/History and Forecast/DateSelector.swift
+++ b/PulseEco/History and Forecast/DateSelector.swift
@@ -16,72 +16,23 @@ struct DateSelector: View {
     
     var body: some View {
         VStack {
-            HStack {
-                Button(action: {
-                    viewModel.isDatePickerPressed.toggle()
-                }) {
-                    HStack {
-                        Text(calendar.isDateInToday(appState.selectedDate) ? Trema.text(for: "today") : viewModel.shortDate(date: appState.selectedDate))
-                            .padding(.leading, 8)
-                        
-                        Spacer()
-                        
-                        Image(systemName: "calendar")
-                            .resizable()
-                            .frame(width: 15, height: 15)
-                            .padding(.trailing, 8)
-                    }
-                    .padding(.vertical, 15)
-                    .font(.caption)
-                    .foregroundStyle(Color(AppColors.firstButtonColor))
-                    .frame(maxWidth: .infinity)
-                    .background(Color.white)
-                    .cornerRadius(5)
-                    .foregroundStyle(Color(AppColors.firstButtonColor))
-                    .overlay(
-                            RoundedRectangle(cornerRadius: 5)
-                                .stroke(Color(AppColors.firstButtonColor), lineWidth: 1)
-                    )
-                }
-                
-                
-                Button(action: {
-                    viewModel.searchButtonTask?.cancel()
-                    viewModel.searchButtonTask = Task {
-                        await appDataSource.selectFromCalendar()
-                    }
-                    viewModel.isDatePickerPressed = false
-                }) {
-                    Text("SEARCH") //add trema
-                        .padding(.vertical, 16)
-                        .padding(.horizontal, 45)
-                        .background(Color(AppColors.firstButtonColor))
-                        .foregroundStyle(Color.white)
-                        .font(.caption)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 45)
-            
+            DateSlider(unimplementedAlert: $appState.showingCalendar,
+                       unimplementedPicker: $viewModel.isDatePickerPressed,
+                       selectedDate: $appState.selectedDate)
             if viewModel.isDatePickerPressed {
-                VStack {
-                    HStack {
-                        CalendarView(showingCalendar: $viewModel.isDatePickerPressed,
-                                     selectedDate: $appState.selectedDate,
-                                     calendarSelection: $appState.calendarSelection,
-                                     onDaySelected: { newDate in viewModel.selectedDate = newDate },
-                                     viewModelClosure: CalendarViewModel(appState: self.appState,
-                                                                         appDataSource: self.appDataSource))
-                        .onChange(of: appState.selectedMeasureId) { newValue in
-                            viewModel.isDatePickerPressed = false
-                            viewModel.onSelectedMeasureChange?.cancel()
-                            viewModel.onSelectedMeasureChange = Task {
-                                await appDataSource.fetchMonthlyDayData(selectedMonth: calendar.component(.month, from: viewModel.selectedDate), selectedYear: calendar.component(.year, from: viewModel.selectedDate))
-                            }
-                        }
-                        
-                        Spacer()
+                CalendarView(showingCalendar: $viewModel.isDatePickerPressed,
+                             selectedDate: $appState.selectedDate,
+                             calendarSelection: $appState.calendarSelection,
+                             onDaySelected: { newDate in viewModel.selectedDate = newDate },
+                             viewModelClosure: CalendarViewModel(appState: self.appState,
+                                                                 appDataSource: self.appDataSource))
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+                .onChange(of: appState.selectedMeasureId) { newValue in
+                    viewModel.isDatePickerPressed = false
+                    viewModel.onSelectedMeasureChange?.cancel()
+                    viewModel.onSelectedMeasureChange = Task {
+                        await appDataSource.fetchMonthlyDayData(selectedMonth: calendar.component(.month, from: viewModel.selectedDate), selectedYear: calendar.component(.year, from: viewModel.selectedDate))
                     }
                 }
             }

--- a/PulseEco/History and Forecast/DateSlider.swift
+++ b/PulseEco/History and Forecast/DateSlider.swift
@@ -1,0 +1,71 @@
+//
+//  DateSlider.swift
+//  PulseEco
+//
+//  Created by Sara Karachanakova on 19.4.22.
+//
+
+import SwiftUI
+
+struct DateSlider: View {
+    
+    @EnvironmentObject var appState: AppState
+    @EnvironmentObject var dataSource: AppDataSource
+    
+    @Binding var unimplementedAlert: Bool
+    @Binding var unimplementedPicker: Bool
+    @Binding var selectedDate: Date
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            ScrollViewReader { proxy in
+                HStack {
+                    Button {
+                        unimplementedAlert.toggle()
+                        unimplementedPicker.toggle()
+                        
+                    } label: {
+                        VStack(spacing: 0) {
+                            Image("history")
+                                .resizable()
+                                .renderingMode(.template)
+                                .foregroundColor(Color.white)
+                                .frame(width: 20, height: 20, alignment: .center)
+                            Text(Trema.text(for: "explore"))
+                                .font(.system(size: 10, weight: .regular))
+                        }
+                        .frame(width: 50, height: 50)
+                        .foregroundColor(Color.white)
+                        .background(Color(AppColors.firstButtonColor))
+                        .cornerRadius(3)
+                        .padding(.leading, 10)
+                    }
+                    LazyHStack {
+                        ForEach(dataSource.weeklyData, id: \.dateId) { item in
+                            WeekDayButton(date: item.date,
+                                          value: item.value,
+                                          color: item.color,
+                                          highlighted: selectedDate.isSameDay(with: item.date)) {
+                                selectedDate = calendar.startOfDay(for: item.date)
+                                Task {
+                                    do {
+                                        await dataSource.updatePins(selectedDate: selectedDate)
+                                    }
+                                }
+                            }
+                        }
+                        .onAppear {
+                            withAnimation {
+                                proxy.scrollTo(selectedDate)
+                            }
+                        }
+                    }
+                }
+                .padding(.trailing, 8)
+            }
+            .frame(height: 64)
+            .background(Color(AppColors.backgroundColorNav))
+        }
+        .background(Color(AppColors.backgroundColorNav))
+    }
+}

--- a/PulseEco/History and Forecast/WeekDayButton.swift
+++ b/PulseEco/History and Forecast/WeekDayButton.swift
@@ -1,0 +1,73 @@
+//
+//  WeekDayButton.swift
+//  PulseEco
+//
+//  Created by Sara Karachanakova on 20.4.22.
+//
+
+import SwiftUI
+import Charts
+
+struct WeekDayButton: View {
+    
+    var date: Date
+    var value: String
+    var color: String
+
+    var opacity: Double {
+        if date > Date.now {
+            return 0.5
+        } else {
+            return 1.0
+        }
+    }
+    
+    var highlighted: Bool = false
+    var action: () -> Void
+    
+    var sevenDaysAgo = calendar.date(byAdding: .day,
+                                             value: -6,
+                                             to: calendar.startOfDay(for: Date.now))
+    
+    func labelFromDate(_ date: Date) -> String {
+        
+        if calendar.isDateInToday(date) {
+            return Trema.text(for: "today")
+        } else if date > sevenDaysAgo! {
+            let dayOfWeek = calendar.dateComponents([.weekday], from: calendar.startOfDay(for: date)).weekday!
+            return calendar.weekdayNameFrom(weekdayNumber: dayOfWeek).capitalized
+        } else {
+            let dateFormatter = DateFormatter()
+            dateFormatter.locale = Locale(identifier: Trema.appLanguageLocale)
+            dateFormatter.dateFormat = "dd MMM"
+            return dateFormatter.string(from: date).capitalized
+        }
+    }
+    
+    var body: some View {
+        
+        HStack {
+                Button {
+                    action()
+                } label: {
+                    VStack(spacing: 3) {
+                        Text(labelFromDate(date))
+                            .font(.system(size: 12, weight: .regular))
+                            .foregroundColor(Color(AppColors.black))
+                        
+                        Text(value)
+                            .font(.system(size: 10, weight: .regular))
+                            .frame(width: 34, height: 12, alignment: .center)
+                            .background(RoundedRectangle(cornerRadius: 3).fill(Color(color)))
+                    }
+                    .frame(width: 50, height: 50)
+                    .foregroundColor(Color(AppColors.white))
+                    .background(Color(AppColors.white))
+                    .cornerRadius(3)
+                }
+                .opacity(opacity)
+                .overlay((self.highlighted) ?
+                         RoundedRectangle(cornerRadius: 3) .stroke(Color(AppColors.borderColor), lineWidth: 1) : nil)
+        }
+    }
+}

--- a/PulseEco/Utility/Extenions/ArrayExtensions.swift
+++ b/PulseEco/Utility/Extenions/ArrayExtensions.swift
@@ -1,0 +1,12 @@
+extension Array where Element: Hashable {
+    /// Get's the most frequent element on the array. First it converts the array to a set, then we map it to a dictionary
+    /// where the key is the value of the array and the value is the number of times the element is in the array,
+    /// Then we need to find the max value from the dictionary and from there return the key which is the original value in the array.
+    var mostFrequentValue: Element? {
+        let set = Set(self)
+        let uniqueKeysWithValues = set.map { ($0, self.filter { $0 == $0 }.count) }
+        let dictionary = Dictionary(uniqueKeysWithValues: uniqueKeysWithValues)
+        let maxEntry = dictionary.max { $0.value < $1.value }
+        return maxEntry?.key
+    }
+}


### PR DESCRIPTION
This PR reverts the calendar to the old view and adds the old weekday selector. It also fixes a couple of bugs that I found with the colors of the dates in the calendar not updating when switching months, selecting a new month but cancelling a the selection of a date and a couple of other minor edge cases.

 
<img width="567" alt="Screenshot 2025-05-05 at 12 06 24" src="https://github.com/user-attachments/assets/3e63b222-5883-4d5a-b6fd-d533caa61b81" />
